### PR TITLE
Don't emit js by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "license": "MIT",
   "scripts": {
     "build": "npm run clean && npm run build-es && npm run build-cjs",
-    "build-es": "tsc --module es2015 --target es2015 --outDir ./es -p tsconfig.json",
-    "build-cjs": "tsc --module commonjs --target es5 --outDir ./lib -p tsconfig.json",
+    "build-es": "tsc --noEmit false --module es2015 --target es2015 --outDir ./es -p tsconfig.json",
+    "build-cjs": "tsc --noEmit false --module commonjs --target es5 --outDir ./lib -p tsconfig.json",
     "build:examples": "cross-env vite build",
     "clean": "rimraf es lib build",
     "prepublish": "cross-env NODE_ENV=production npm run build",
@@ -61,6 +61,6 @@
     "vitest": "^0.2.5"
   },
   "peerDependencies": {
-    "react": "^16.8.0-0 || ^17.0.0-0"
+    "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "noImplicitOverride": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "alwaysStrict": true,
+    "noEmit": true,
   },
   "include": ["src/index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "alwaysStrict": true,
-    "noEmit": true,
+    "noEmit": true
   },
   "include": ["src/index.ts"]
 }


### PR DESCRIPTION
The lack of a specified output directory causes the executing of `npx tsc` (useful command for typechecking) to generate `.js` and `.d.ts` files in the `src` directory. This is convenient to deal with.

This PR changes the behavior of tsconfig to not emit anything by default, and let's the commands in `package.json` override that behavior.